### PR TITLE
Unmangle field names if `DuplicateRecordFields` is turned on

### DIFF
--- a/barbies-th.cabal
+++ b/barbies-th.cabal
@@ -18,6 +18,7 @@ library
   build-depends:       base >= 4.12
     , template-haskell >= 2.14 && <2.17
     , barbies ^>= 2.0.1
+    , split ^>= 0.2
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options: -Wall


### PR DESCRIPTION
Fixes #3