### PR TITLE
Add a note about instance deriving to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ deriving via Barbie (Foo Covered) h instance Show (Barbie (Foo Covered) h) => Sh
 deriving via Barbie (Foo Covered) h instance Eq (Barbie (Foo Covered) h) => Eq (Foo Covered h)
 ```
 
+Note that `Barbies` module must be imported manually.
+
 Matryoshka barbies
 ----
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ instance ProductBC (Foo Covered)
 
 Typically you need the following extensions to make `declareBareB` work:
 
-```
+```haskell
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -54,11 +54,13 @@ Deriving pass-through
 stock deriving does not work on HKDs. Instead, it transforms deriving clauses into standalone ones via the `Barbie` wrapper,
 as well as ones for the `Bare` counterpart. For example,
 
-`data Foo = ... deriving (Show, Eq)`
+```haskell
+data Foo = ... deriving (Show, Eq)
+```
 
 generates
 
-```
+```haskell
 deriving instance Show (Foo Bare Identity)
 deriving instance Eq (Foo Bare Identity)
 deriving via Barbie (Foo Covered) h instance Show (Barbie (Foo Covered) h) => Show (Foo Covered h)


### PR DESCRIPTION
I added a note about instance deriving because the following code raises a compiler error without `Barbies` module.

```haskell
declareBareB
    [d|
        data Foo = ... deriving (Show, Eq)
    |]
```