### PR TITLE
Bugfix empty record

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -53,5 +53,8 @@ test_sel = (foo test_con, bar test_con)
 test_upd :: Foo Covered []
 test_upd = test_con { foo = [], bar = [] }
 
+test_empty :: (EmptyRecord Covered [], EmptyRecord Covered Maybe)
+test_empty = (EmptyRecord, EmptyRecord)
+
 main = pure ()
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -37,6 +37,10 @@ declareBareBWithOtherBarbies [''Foo] [d|
     }
     |]
 
+declareBareB [d|
+  data EmptyRecord = EmptyRecord {}
+    |]
+
 test_con :: Foo Covered []
 test_con = Foo
   { foo = [0]


### PR DESCRIPTION
1. This fixes a problem where barbies-th couldn't generate barbies for empty record types like this:
```haskell
declareBareB [d|data Foo2 = Foo2 { } |]
```

2. This also adds a kind annotation to the clothing parameter. For empty record types this parameter otherwise ends up unconstrained and requires PolyKinds in the file calling "declareBareB".
```haskell
data Foo2 sw_a3Ok (h_a3Ol :: ghc-prim-0.7.0:GHC.Types.Type
                                -> ghc-prim-0.7.0:GHC.Types.Type)
      = ...
```

There's a missing pure in the generated code for the TraversableB instance.
```haskell
data Foo2 sw_aenE h_aenF  = Foo2_aenD {}
instance FunctorB (Foo2 Covered) where
  bmap f_aenJ Foo2_aenD = Foo2_aenD
instance TraversableB (Foo2 Covered) where
  --                           VVVVVVVVVV
   btraverse f_aenL Foo2_aenD = {- pure -} Foo2_aenD
```

```shell
src/Lib.hs:28:43: error:
    • Couldn't match type ‘e’ with ‘Foo2 sw_aenE0’
      ‘e’ is a rigid type variable bound by
        the type signature for:
          btraverse :: forall (e :: * -> *) (f :: k -> *) (g :: k -> *).
                       Applicative e =>
                       (forall (a :: k). f a -> e (g a))
                       -> Foo2 Covered f -> e (Foo2 Covered g)
        at src/Lib.hs:28:3-11
      Expected type: e (Foo2 Covered g)
        Actual type: Foo2 sw_aenE0 (Foo2 Covered g)
    • In the expression: Foo2_aenD
      In an equation for ‘btraverse’:
          btraverse f_aenL Foo2_aenD = Foo2_aenD
      In the instance declaration for ‘TraversableB (Foo2 Covered)’
    • Relevant bindings include
        f_aenL :: forall (a :: k). f a -> e (g a)
          (bound at src/Lib.hs:28:13)
        btraverse :: (forall (a :: k). f a -> e (g a))
                     -> Foo2 Covered f -> e (Foo2 Covered g)
          (bound at src/Lib.hs:28:3)
   |
28 |   btraverse f_aenL Foo2_aenD = {- pure -} Foo2_aenD
   |                                           ^^^^^^^^^
```

Compare with the generated code for:
```haskell
declareBareB [d|data Foo = Foo { foo :: Integer } |]
```

```haskell
data Foo sw_aeaV h_aeaW  = Foo_aeaT {foo_aeaU :: (Wear sw_aeaV h_aeaW Integer)}
instance FunctorB (Foo Covered) where
  bmap f_aeb0 (Foo_aeaT xfoo) = Foo_aeaT (f_aeb0 xfoo)
instance TraversableB (Foo Covered) where
  btraverse f_aeb2 (Foo_aeaT xfoo) = (Foo_aeaT <$> f_aeb2 xfoo)
```

Thanks :)