### PR TITLE
barbies-th.cabal: Raise upper bounds: base, template-haskell

### DIFF
--- a/barbies-th.cabal
+++ b/barbies-th.cabal
@@ -27,8 +27,8 @@ library
     Barbies.TH.Config
     Data.Barbie.TH
   other-extensions:    RankNTypes, PolyKinds, DataKinds, KindSignatures, TemplateHaskell, TypeFamilies
-  build-depends:       base >= 4.12 && <4.17
-    , template-haskell >= 2.14 && <2.19
+  build-depends:       base >= 4.12 && <4.18
+    , template-haskell >= 2.14 && <2.20
     , barbies ^>= 2.0.1
     , split ^>= 0.2
   hs-source-dirs:      src
@@ -41,7 +41,7 @@ test-suite th
   hs-source-dirs:
       tests
   build-depends:
-      base >=4.7 && <5
+      base
     , barbies
     , barbies-th
   default-language: Haskell2010
@@ -52,7 +52,7 @@ test-suite th-passthrough
   hs-source-dirs:
       tests
   build-depends:
-      base >=4.7 && <5
+      base
     , barbies
     , barbies-th
   default-language: Haskell2010


### PR DESCRIPTION
And remove bounds on `base` in the test suites, since they'll be constrained by library dependency bounds anyway.

Tested on an internal project which isn't yet ready for public release, but `barbies-th` builds and runs under the relaxed constraints.

Can I please also have a Hackage metadata revision for this?