### PR TITLE
Support upto GHC 9.8.2

### DIFF
--- a/barbies-th.cabal
+++ b/barbies-th.cabal
@@ -32,8 +32,8 @@ library
     Barbies.TH.Config
     Data.Barbie.TH
   other-extensions:    RankNTypes, PolyKinds, DataKinds, KindSignatures, TemplateHaskell, TypeFamilies
-  build-depends:       base >= 4.12 && <4.18
-    , template-haskell >= 2.14 && <2.20
+  build-depends:       base >= 4.12 && <4.20
+    , template-haskell >= 2.14 && <2.22
     , barbies ^>= 2.0.1
     , split ^>= 0.2
   hs-source-dirs:      src

--- a/src/Barbies/TH.hs
+++ b/src/Barbies/TH.hs
@@ -257,7 +257,9 @@ declareBareBWith DeclareBareBConfig{..} decsQ = do
         standaloneDerivWithStrategyD strat (pure []) [t|$(cls) $(pure bareType)|])
         [ (strat, pure t) | (_, DerivClause strat preds) <- classes', t <- preds ]
       return $ DataD [] dataName
-#if MIN_VERSION_template_haskell(2,17,0)
+#if MIN_VERSION_template_haskell(2,21,0)
+        (tvbs ++ [PlainTV nSwitch BndrReq, KindedTV nWrap BndrReq (AppT (AppT ArrowT StarT) StarT)])
+#elif MIN_VERSION_template_haskell(2,17,0)
         (tvbs ++ [PlainTV nSwitch (), KindedTV nWrap () (AppT (AppT ArrowT StarT) StarT)])
 #else
         (tvbs ++ [PlainTV nSwitch, KindedTV nWrap (AppT (AppT ArrowT StarT) StarT)])


### PR DESCRIPTION
Bumped `base` and `template-haskell`'s upper bound.
Added a fix for [change in templated haskell 2.21.0](https://hackage.haskell.org/package/template-haskell-2.21.0.0/changelog).

Confirmed it compiles and passes test for following GHC version:
- 9.8.2(base-4.19.1.0)
- 9.8.1(base-4.19.0.0)
- 9.6.5(base-4.18.2.0)
- 9.6.4(base-4.18.2.0)
- 9.6.3(base-4.18.1.0)
- 9.6.2(base-4.18.0.0)
- 9.4.8(base-4.17.2.1)
